### PR TITLE
lets enable by default, process initial BuildConfigs on start (in a background thread to avoid exceptions on startup), lets also support fabric8 annotations for current fabric8 projects in current Origin and lets only prepend the namespace on builds not in the default namespace (to avoid namespace noise if folks run 1 jenkins per namespace)

### DIFF
--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigToJobMapper.java
@@ -26,19 +26,24 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public class BuildConfigToJobMapper {
 
-  public static Job<WorkflowJob, WorkflowRun> mapBuildConfigToJob(BuildConfig bc) {
+  public static Job<WorkflowJob, WorkflowRun> mapBuildConfigToJob(BuildConfig bc, String defaultNamespace) {
     GitSCM scm = new GitSCM(bc.getSpec().getSource().getGit().getUri());
 
     FlowDefinition flowDefinition = new CpsScmFlowDefinition(scm, "Jenkinsfile");
 
-    WorkflowJob job = new WorkflowJob(Jenkins.getInstance(), jobName(bc));
+    WorkflowJob job = new WorkflowJob(Jenkins.getInstance(), jobName(bc, defaultNamespace));
     job.setDefinition(flowDefinition);
 
     return job;
   }
 
-  public static String jobName(BuildConfig bc) {
-    return bc.getMetadata().getNamespace() + "-" + bc.getMetadata().getName();
+  public static String jobName(BuildConfig bc, String defaultNamespace) {
+    String namespace = bc.getMetadata().getNamespace();
+    String name = bc.getMetadata().getName();
+    if (namespace == null || namespace.length() == 0 || namespace.equals(defaultNamespace)) {
+      return name;
+    }
+    return namespace + "-" + name;
   }
 
 }

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/BuildConfigWatcher.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/NamespaceName.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/NamespaceName.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2016 Red Hat, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.jenkins.openshiftsync;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+/**
+ * Represents a name in a namespace we can use as a key in a map
+ */
+public class NamespaceName {
+  private final String namespace;
+  private final String name;
+
+  public NamespaceName(String namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  public static NamespaceName create(HasMetadata hasMetadata) {
+    notNull(hasMetadata, "resource");
+    ObjectMeta metadata = hasMetadata.getMetadata();
+    notNull(metadata, "metadata");
+    String name = metadata.getName();
+    String namespace = metadata.getNamespace();
+    notNull(name, "metadata.name");
+    notNull(namespace, "metadata.namespace");
+    return new NamespaceName(namespace, name);
+  }
+
+  @Override
+  public String toString() {
+    return "NamespaceName{" +
+      namespace + ":" + name +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    NamespaceName that = (NamespaceName) o;
+
+    if (!namespace.equals(that.namespace)) return false;
+    return name.equals(that.name);
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = namespace.hashCode();
+    result = 31 * result + name.hashCode();
+    return result;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+
+  /**
+   * Asserts whether the value is <b>not</b> <tt>null</tt>
+   *
+   * @param value  the value to test
+   * @param name   the key that resolved the value
+   * @throws IllegalArgumentException is thrown if assertion fails
+   */
+  public static void notNull(Object value, String name) {
+    if (value == null) {
+      throw new IllegalArgumentException(name + " must be specified");
+    }
+  }
+}

--- a/src/main/java/io/fabric8/jenkins/openshiftsync/NamespaceName.java
+++ b/src/main/java/io/fabric8/jenkins/openshiftsync/NamespaceName.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Red Hat, Inc.
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
lets enable by default, process initial BuildConfigs on start (in a background thread to avoid exceptions on startup), lets also support fabric8 annotations for current fabric8 projects in current Origin and lets only prepend the namespace on builds not in the default namespace (to avoid namespace noise if folks run 1 jenkins per namespace)